### PR TITLE
Add black formatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,12 @@
 [flake8]
-max-line-length = 119
 exclude =
     .venv
 ignore =
+    # For compatibility with black:
+    E203,
+    E701,
+    E704,
+    # Let black manage the line length:
+    E501,
     # See https://www.flake8rules.com/rules/W503.html
     W503

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# [2024-02-09] Format all Python files with black
+681cab1e32244a9460bc305fd630d2b0e2af6ff7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,7 @@ jobs:
         run: isort --settings-path isort.cfg --check-only src tests
       - name: Validate Python syntax with flake8
         run: flake8 --config .flake8 src tests
+      - name: Check Python formatting with black
+        run: black --check .
       - name: Run tests
         run: python run_tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Reformat source code with with [black](https://pypi.org/project/black/)
+
 ## 1.1.0 - 2024-02-04
 
 - Add official support for Django 3.2:

--- a/isort.cfg
+++ b/isort.cfg
@@ -1,2 +1,2 @@
 [isort]
-profile=django
+profile=black

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,6 +2,6 @@ import os
 
 import pytest
 
-if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
     pytest.main()

--- a/src/django_safe_template_engine/engine.py
+++ b/src/django_safe_template_engine/engine.py
@@ -5,8 +5,8 @@ class SafeTemplateEngine(Engine):
 
     def __init__(self, **kwargs):
         self.default_builtins = [
-            'django_safe_template_engine.trusted_filters',
-            'django_safe_template_engine.trusted_tags',
+            "django_safe_template_engine.trusted_filters",
+            "django_safe_template_engine.trusted_tags",
         ]
 
         super().__init__(**kwargs)

--- a/src/django_safe_template_engine/trusted_filters.py
+++ b/src/django_safe_template_engine/trusted_filters.py
@@ -1,13 +1,59 @@
 from django.template.defaultfilters import (
-    add, addslashes, capfirst, center, cut, date, default, default_if_none,
-    dictsort, dictsortreversed, divisibleby, escape_filter, escapejs_filter,
-    filesizeformat, first, floatformat, force_escape, get_digit, iriencode,
-    join, json_script, last, length, length_is, linebreaks_filter,
-    linebreaksbr, linenumbers, ljust, lower, make_list, phone2numeric_filter,
-    pluralize, random, rjust, safe, safeseq, slice_filter, slugify,
-    stringformat, striptags, time, timesince_filter, timeuntil_filter, title,
-    truncatechars, truncatechars_html, truncatewords, truncatewords_html,
-    unordered_list, upper, urlencode, urlize, urlizetrunc, wordcount, wordwrap,
+    add,
+    addslashes,
+    capfirst,
+    center,
+    cut,
+    date,
+    default,
+    default_if_none,
+    dictsort,
+    dictsortreversed,
+    divisibleby,
+    escape_filter,
+    escapejs_filter,
+    filesizeformat,
+    first,
+    floatformat,
+    force_escape,
+    get_digit,
+    iriencode,
+    join,
+    json_script,
+    last,
+    length,
+    length_is,
+    linebreaks_filter,
+    linebreaksbr,
+    linenumbers,
+    ljust,
+    lower,
+    make_list,
+    phone2numeric_filter,
+    pluralize,
+    random,
+    rjust,
+    safe,
+    safeseq,
+    slice_filter,
+    slugify,
+    stringformat,
+    striptags,
+    time,
+    timesince_filter,
+    timeuntil_filter,
+    title,
+    truncatechars,
+    truncatechars_html,
+    truncatewords,
+    truncatewords_html,
+    unordered_list,
+    upper,
+    urlencode,
+    urlize,
+    urlizetrunc,
+    wordcount,
+    wordwrap,
     yesno,
 )
 from django.template.library import Library
@@ -16,7 +62,7 @@ register = Library()
 
 register.filter(addslashes, is_safe=True)
 register.filter(capfirst, is_safe=True)
-register.filter('escapejs', escapejs_filter)
+register.filter("escapejs", escapejs_filter)
 register.filter(json_script, is_safe=True)
 register.filter(floatformat, is_safe=True)
 register.filter(iriencode, is_safe=True)
@@ -40,9 +86,9 @@ register.filter(ljust, is_safe=True)
 register.filter(rjust, is_safe=True)
 register.filter(center, is_safe=True)
 register.filter(cut)
-register.filter('escape', escape_filter, is_safe=True)
+register.filter("escape", escape_filter, is_safe=True)
 register.filter(force_escape, is_safe=True)
-register.filter('linebreaks', linebreaks_filter, is_safe=True, needs_autoescape=True)
+register.filter("linebreaks", linebreaks_filter, is_safe=True, needs_autoescape=True)
 register.filter(linebreaksbr, is_safe=True, needs_autoescape=True)
 register.filter(safe, is_safe=True)
 register.filter(safeseq, is_safe=True)
@@ -55,18 +101,18 @@ register.filter(last, is_safe=True)
 register.filter(length, is_safe=False)
 register.filter(length_is, is_safe=False)
 register.filter(random, is_safe=True)
-register.filter('slice', slice_filter, is_safe=True)
+register.filter("slice", slice_filter, is_safe=True)
 register.filter(unordered_list, is_safe=True, needs_autoescape=True)
 register.filter(add, is_safe=False)
 register.filter(get_digit, is_safe=False)
 register.filter(date, expects_localtime=True, is_safe=False)
 register.filter(time, expects_localtime=True, is_safe=False)
-register.filter('timesince', timesince_filter, is_safe=False)
-register.filter('timeuntil', timeuntil_filter, is_safe=False)
+register.filter("timesince", timesince_filter, is_safe=False)
+register.filter("timeuntil", timeuntil_filter, is_safe=False)
 register.filter(default, is_safe=False)
 register.filter(default_if_none, is_safe=False)
 register.filter(divisibleby, is_safe=False)
 register.filter(yesno, is_safe=False)
 register.filter(filesizeformat, is_safe=True)
 register.filter(pluralize, is_safe=False)
-register.filter('phone2numeric', phone2numeric_filter, is_safe=True)
+register.filter("phone2numeric", phone2numeric_filter, is_safe=True)

--- a/src/django_safe_template_engine/trusted_tags.py
+++ b/src/django_safe_template_engine/trusted_tags.py
@@ -1,7 +1,22 @@
 from django.template.defaulttags import (
-    autoescape, comment, cycle, do_filter, do_for, do_if, do_with, firstof,
-    ifchanged, lorem, now, regroup, resetcycle, spaceless, templatetag, url,
-    verbatim, widthratio,
+    autoescape,
+    comment,
+    cycle,
+    do_filter,
+    do_for,
+    do_if,
+    do_with,
+    firstof,
+    ifchanged,
+    lorem,
+    now,
+    regroup,
+    resetcycle,
+    spaceless,
+    templatetag,
+    url,
+    verbatim,
+    widthratio,
 )
 from django.template.library import Library
 
@@ -10,10 +25,10 @@ register = Library()
 register.tag(autoescape)
 register.tag(comment)
 register.tag(cycle)
-register.tag('filter', do_filter)
+register.tag("filter", do_filter)
 register.tag(firstof)
-register.tag('for', do_for)
-register.tag('if', do_if)
+register.tag("for", do_for)
+register.tag("if", do_if)
 register.tag(ifchanged)
 register.tag(lorem)
 register.tag(now)
@@ -24,4 +39,4 @@ register.tag(templatetag)
 register.tag(url)
 register.tag(verbatim)
 register.tag(widthratio)
-register.tag('with', do_with)
+register.tag("with", do_with)

--- a/src/django_safe_template_engine/validators.py
+++ b/src/django_safe_template_engine/validators.py
@@ -7,5 +7,5 @@ from django_safe_template_engine.engine import SafeTemplateEngine
 def validate_safe_engine_template_syntax(source):
     try:
         Template(source, engine=SafeTemplateEngine())
-    except (TemplateSyntaxError) as err:
+    except TemplateSyntaxError as err:
         raise ValidationError(str(err))

--- a/tests/filters/test_trusted_filters.py
+++ b/tests/filters/test_trusted_filters.py
@@ -12,65 +12,67 @@ class TestTrustedFilters:
         return template.render(Context(context))
 
     def test_trust_addslashes(self):
-        expected = '\\\\test'
+        expected = "\\\\test"
         result = self._render('{{ "\\test"|addslashes }}')
         assert result == expected
 
     def test_trust_capfist(self):
-        expected = 'Hello world'
+        expected = "Hello world"
         result = self._render('{{ "hello world"|capfirst }}')
         assert result == expected
 
     def test_trust_escapejs(self):
-        expected = '\\u003Ctest\\u0026test\\u003E'
+        expected = "\\u003Ctest\\u0026test\\u003E"
         result = self._render('{{ "<test&test>"|escapejs }}')
         assert result == expected
 
     def test_trust_json_script(self):
-        expected = '<script id="test-id" type="application/json">"{\\"id\\": 1}"</script>'
+        expected = (
+            '<script id="test-id" type="application/json">"{\\"id\\": 1}"</script>'
+        )
         result = self._render(
             '{{ json_string|json_script:"test-id" }}',
-            context={'json_string': '{"id": 1}'}
+            context={"json_string": '{"id": 1}'},
         )
         assert result == expected
 
     def test_trust_floatformat(self):
-        expected = '42'
-        result = self._render('{{ 42.0000|floatformat }}')
+        expected = "42"
+        result = self._render("{{ 42.0000|floatformat }}")
         assert result == expected
 
     # TODO: Write test for iriencode
 
     def test_trust_linenumbers(self):
-        expected = '1. one\n2. two\n3. three'
+        expected = "1. one\n2. two\n3. three"
         result = self._render(
-            '{{ value|linenumbers }}',
-            context={'value': 'one\ntwo\nthree'},
+            "{{ value|linenumbers }}",
+            context={"value": "one\ntwo\nthree"},
         )
         assert result == expected
 
     def test_trust_lower(self):
-        expected = 'hello'
+        expected = "hello"
         result = self._render('{{ "HeLlO"|lower }}')
         assert result == expected
 
     def test_trust_make_list(self):
         expected = "[&#x27;1&#x27;, &#x27;2&#x27;, &#x27;3&#x27;]"
         result = self._render(
-            '{{ value|make_list }}',
-            context={'value': '123'},
+            "{{ value|make_list }}",
+            context={"value": "123"},
         )
         assert result == expected
 
     def test_trust_slugify(self):
-        expected = 'hello-world'
+        expected = "hello-world"
         result = self._render('{{ "hello world"|slugify }}')
         assert result == expected
 
     # TODO: Write test for stringformat
 
     def test_trust_title(self):
-        expected = 'Hello World'
+        expected = "Hello World"
         result = self._render('{{ "hello world"|title }}')
         assert result == expected
 
@@ -80,7 +82,7 @@ class TestTrustedFilters:
     # TODO: Write test for truncatewords_html
 
     def test_trust_upper(self):
-        expected = 'HELLO'
+        expected = "HELLO"
         result = self._render('{{ "HeLlO"|upper }}')
         assert result == expected
 
@@ -104,10 +106,10 @@ class TestTrustedFilters:
     # TODO: Write test for dictsortreversed
 
     def test_trust_first(self):
-        expected = 'test1'
+        expected = "test1"
         result = self._render(
-            '{{ value|first }}',
-            context={'value': ['test1', 'test2']},
+            "{{ value|first }}",
+            context={"value": ["test1", "test2"]},
         )
         assert result == expected
 
@@ -127,28 +129,28 @@ class TestTrustedFilters:
     # TODO: Write test for timeuntil
 
     def test_trust_default(self):
-        expected = 'OK'
+        expected = "OK"
         result = self._render(
             '{{ value|default:"OK" }}',
-            context={'value': False},
+            context={"value": False},
         )
         assert result == expected
 
     def test_trust_default_if_none(self):
-        expected = 'OK'
+        expected = "OK"
         result = self._render(
             '{{ value|default_if_none:"OK" }}',
-            context={'value': None},
+            context={"value": None},
         )
         assert result == expected
 
     # TODO: Write test for divisibleby
 
     def test_trust_yesno(self):
-        expected = 'No'
+        expected = "No"
         result = self._render(
             '{{ value|yesno:"Yes,No" }}',
-            context={'value': False},
+            context={"value": False},
         )
         assert result == expected
 
@@ -159,14 +161,14 @@ class TestTrustedFilters:
     #     assert result == expected
 
     def test_trust_pluralize(self):
-        expected = 'tests'
+        expected = "tests"
         result = self._render(
-            'test{{ value|pluralize }}',
-            context={'value': 2},
+            "test{{ value|pluralize }}",
+            context={"value": 2},
         )
         assert result == expected
 
     def test_trust_phone2numeric(self):
-        expected = '800-2655328'
+        expected = "800-2655328"
         result = self._render('{{ "800-COLLECT"|phone2numeric }}')
         assert result == expected

--- a/tests/filters/test_untrusted_filters.py
+++ b/tests/filters/test_untrusted_filters.py
@@ -19,9 +19,6 @@ class TestUntrustedFilters:
     def test_do_not_trust_pprint(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('pprint'),
+            match=self._msg_regex("pprint"),
         ):
-            self._render(
-                '{{ test_list|pprint }}',
-                context={'test_list': []}
-            )
+            self._render("{{ test_list|pprint }}", context={"test_list": []})

--- a/tests/loaders/test_untrusted_loaders.py
+++ b/tests/loaders/test_untrusted_loaders.py
@@ -19,27 +19,27 @@ class TestUntrustedLoaders:
     def test_do_not_trust_block(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('block'),
+            match=self._msg_regex("block"),
         ):
-            self._render('{% block content %}{% endblockcontent %}')
+            self._render("{% block content %}{% endblockcontent %}")
 
     def test_do_not_trust_extends(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('extends'),
+            match=self._msg_regex("extends"),
         ):
             self._render('{% extends "hacked.html" %}')
 
     def test_do_not_trust_include(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('include'),
+            match=self._msg_regex("include"),
         ):
             self._render('{% include "hacked.html" %}')
 
     def test_do_not_trust_static(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('static'),
+            match=self._msg_regex("static"),
         ):
             self._render('{% static "hacked.css" %}')

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,7 @@
 ..
 
 # Coding style / typing:
+black
 flake8
 isort
 mypy

--- a/tests/tags/test_trusted_tags.py
+++ b/tests/tags/test_trusted_tags.py
@@ -14,21 +14,16 @@ class TestTrustedTags:
         return template.render(Context(context))
 
     def test_trust_autoescape(self):
-        expected = '<script></script>'
+        expected = "<script></script>"
         result = self._render(
-            '{% autoescape off %}'
-            '<script></script>'
-            '{% endautoescape %}',
+            "{% autoescape off %}" "<script></script>" "{% endautoescape %}",
         )
         assert result == expected
 
     def test_trust_comment(self):
-        expected = 'Displayed'
+        expected = "Displayed"
         result = self._render(
-            'Displayed'
-            '{% comment %}'
-            'Hidden'
-            '{% endcomment %}',
+            "Displayed" "{% comment %}" "Hidden" "{% endcomment %}",
         )
         assert result == expected
 
@@ -36,23 +31,20 @@ class TestTrustedTags:
         expected = (
             '<span class="text1">First text</span>'
             '<span class="text2">Second text</span>'
-
         )
         result = self._render(
-            '{% for item in items %}'
+            "{% for item in items %}"
             '<span class="{% cycle "text1" "text2" "text3" %}">{{ item }}</span>'
-            '{% endfor %}',
-            context={'items': ['First text', 'Second text']}
+            "{% endfor %}",
+            context={"items": ["First text", "Second text"]},
         )
         assert result == expected
 
     def test_trust_filter(self):
-        expected = '1. ONE\n2. TWO\n3. THREE'
+        expected = "1. ONE\n2. TWO\n3. THREE"
         result = self._render(
-            '{% filter linenumbers|upper %}'
-            'one\ntwo\nthree'
-            '{% endfilter %}',
-            context={'value': 'one\ntwo\nthree'},
+            "{% filter linenumbers|upper %}" "one\ntwo\nthree" "{% endfilter %}",
+            context={"value": "one\ntwo\nthree"},
         )
         assert result == expected
 
@@ -62,62 +54,60 @@ class TestTrustedTags:
             match=r"^Invalid filter: 'pprint'",
         ):
             self._render(
-                '{% filter pprint %}'
-                'Unreachable due to usage of pprint filter'
-                '{% endfilter %}',
+                "{% filter pprint %}"
+                "Unreachable due to usage of pprint filter"
+                "{% endfilter %}",
             )
 
     def test_trust_firstof(self):
-        expected = 'OK'
+        expected = "OK"
         result = self._render(
             '{% firstof empty "OK" %}',
-            context={'empty': ''},
+            context={"empty": ""},
         )
         assert result == expected
 
     def test_trust_for(self):
-        expected = '123'
+        expected = "123"
         result = self._render(
-            '{% for item in items %}'
-            '{{ item }}'
-            '{% endfor %}',
-            context={'items': [1, 2, 3]},
+            "{% for item in items %}" "{{ item }}" "{% endfor %}",
+            context={"items": [1, 2, 3]},
         )
         assert result == expected
 
     def test_trust_for_empty(self):
-        expected = 'No items'
+        expected = "No items"
         result = self._render(
-            '{% for item in items %}'
-            '{{ item }}'
-            '{% empty %}'
-            'No items'
-            '{% endfor %}',
-            context={'items': []},
+            "{% for item in items %}"
+            "{{ item }}"
+            "{% empty %}"
+            "No items"
+            "{% endfor %}",
+            context={"items": []},
         )
         assert result == expected
 
     def test_trust_if(self):
-        expected = 'New messages'
+        expected = "New messages"
         result = self._render(
-            '{% if messages %}'
-            'New messages'
-            '{% else %}'
-            'No new messages'
-            '{% endif %}',
-            context={'messages': ['message1', 'message2']}
+            "{% if messages %}"
+            "New messages"
+            "{% else %}"
+            "No new messages"
+            "{% endif %}",
+            context={"messages": ["message1", "message2"]},
         )
         assert result == expected
 
     def test_trust_if_with_trusted_filter(self):
-        expected = 'New messages'
+        expected = "New messages"
         result = self._render(
-            '{% if messages|length > 0 %}'
-            'New messages'
-            '{% else %}'
-            'No new messages'
-            '{% endif %}',
-            context={'messages': ['message1', 'message2']}
+            "{% if messages|length > 0 %}"
+            "New messages"
+            "{% else %}"
+            "No new messages"
+            "{% endif %}",
+            context={"messages": ["message1", "message2"]},
         )
         assert result == expected
 
@@ -127,28 +117,28 @@ class TestTrustedTags:
             match=r"^Invalid filter: 'pprint'",
         ):
             self._render(
-                '{% if messages|pprint %}'
-                'Unreachable due to usage of pprint filter'
-                '{% endif %}',
+                "{% if messages|pprint %}"
+                "Unreachable due to usage of pprint filter"
+                "{% endif %}",
             )
 
     def test_trust_ifchanged(self):
-        expected = '123'
+        expected = "123"
         result = self._render(
-            '{% for number in numbers %}'
-            '{% ifchanged number %}{{ number }}{% endifchanged %}'
-            '{% endfor %}',
-            context={'numbers': [1, 1, 2, 3, 3]}
+            "{% for number in numbers %}"
+            "{% ifchanged number %}{{ number }}{% endifchanged %}"
+            "{% endfor %}",
+            context={"numbers": [1, 1, 2, 3, 3]},
         )
         assert result == expected
 
     def test_trust_lorem(self):
-        expected = 'Lorem ipsum'
-        result = self._render('{% lorem 1 b %}')
+        expected = "Lorem ipsum"
+        result = self._render("{% lorem 1 b %}")
         assert result.startswith(expected) is True
 
     def test_trust_now(self):
-        expected = ['0', '1']
+        expected = ["0", "1"]
         result = self._render('{% now "I" %}')
         assert result in expected
 
@@ -158,54 +148,49 @@ class TestTrustedTags:
         expected = (
             '<span class="text1">First text</span>'
             '<span class="text1">Second text</span>'
-
         )
         result = self._render(
-            '{% for item in items %}'
+            "{% for item in items %}"
             '<span class="{% cycle "text1" "text2" "text3" %}">{{ item }}</span>'
-            '{% resetcycle %}'
-            '{% endfor %}',
-            context={'items': ['First text', 'Second text']}
+            "{% resetcycle %}"
+            "{% endfor %}",
+            context={"items": ["First text", "Second text"]},
         )
         assert result == expected
 
     def test_trust_spaceless(self):
-        expected = '<p><strong>Test</strong></p>'
+        expected = "<p><strong>Test</strong></p>"
         result = self._render(
-            '''{% spaceless %}
+            """{% spaceless %}
             <p>
                 <strong>Test</strong>
             </p>
-            {% endspaceless %}''',
+            {% endspaceless %}""",
         )
         assert result == expected
 
     def test_trust_templatetag(self):
-        expected = '{%'
-        result = self._render('{% templatetag openblock %}')
+        expected = "{%"
+        result = self._render("{% templatetag openblock %}")
         assert result == expected
 
     # TODO: Write test for url
 
     def test_trust_verbatim(self):
-        expected = '{% test %}'
+        expected = "{% test %}"
         result = self._render(
-            '{% verbatim %}'
-            '{% test %}'
-            '{% endverbatim %}',
+            "{% verbatim %}" "{% test %}" "{% endverbatim %}",
         )
         assert result == expected
 
     def test_trust_widthratio(self):
-        expected = '88'
-        result = self._render('{% widthratio 175 200 100 %}')
+        expected = "88"
+        result = self._render("{% widthratio 175 200 100 %}")
         assert result == expected
 
     def test_trust_with(self):
-        expected = '1 / 2'
+        expected = "1 / 2"
         result = self._render(
-            '{% with alpha=1 beta=2 %}'
-            '{{ alpha }} / {{ beta }}'
-            '{% endwith %}',
+            "{% with alpha=1 beta=2 %}" "{{ alpha }} / {{ beta }}" "{% endwith %}",
         )
         assert result == expected

--- a/tests/tags/test_untrusted_tags.py
+++ b/tests/tags/test_untrusted_tags.py
@@ -19,41 +19,41 @@ class TestUntrustedTags:
     def test_do_not_trust_block(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('block'),
+            match=self._msg_regex("block"),
         ):
-            self._render('{% block main %}')
+            self._render("{% block main %}")
 
     def test_do_not_trust_csrf_token(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('csrf_token'),
+            match=self._msg_regex("csrf_token"),
         ):
-            self._render('{% csrf_token %}')
+            self._render("{% csrf_token %}")
 
     def test_do_not_trust_debug(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('debug'),
+            match=self._msg_regex("debug"),
         ):
-            self._render('{% debug %}')
+            self._render("{% debug %}")
 
     def test_do_not_trust_extends(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('extends'),
+            match=self._msg_regex("extends"),
         ):
             self._render('{% extends "hacked.html" %}')
 
     def test_do_not_trust_include(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('include'),
+            match=self._msg_regex("include"),
         ):
             self._render('{% include "hacked.html" %}')
 
     def test_do_not_trust_load(self):
         with pytest.raises(
             TemplateSyntaxError,
-            match=self._msg_regex('load'),
+            match=self._msg_regex("load"),
         ):
-            self._render('{% load i18n %}')
+            self._render("{% load i18n %}")

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,9 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from django_safe_template_engine.validators import (
-    validate_safe_engine_template_syntax,
-)
+from django_safe_template_engine.validators import validate_safe_engine_template_syntax
 
 
 class TestValidateSafeEngineTemplateSyntax:
@@ -13,22 +11,22 @@ class TestValidateSafeEngineTemplateSyntax:
 
     def test_valid_template(self):
         self._validate(
-            '{% autoescape off %}'
+            "{% autoescape off %}"
             '<script>{{ "i am a test"|title }}</script>'
-            '{% endautoescape %}'
+            "{% endautoescape %}"
         )
 
     def test_generic_invalid_syntax(self):
         with pytest.raises(ValidationError):
-            self._validate('{% i_do_not_exist %}')
+            self._validate("{% i_do_not_exist %}")
         with pytest.raises(ValidationError):
-            self._validate('{{ test|i_do_not_exist }}')
+            self._validate("{{ test|i_do_not_exist }}")
         with pytest.raises(ValidationError):
-            self._validate('{% if %} Unclosed if')
+            self._validate("{% if %} Unclosed if")
 
     def test_invalid_template_untrusted_loader(self):
         with pytest.raises(ValidationError):
-            self._validate('{% load i18n %}')
+            self._validate("{% load i18n %}")
 
     def test_invalid_template_untrusted_tag(self):
         with pytest.raises(ValidationError):
@@ -36,4 +34,4 @@ class TestValidateSafeEngineTemplateSyntax:
 
     def test_invalid_template_untrusted_filter(self):
         with pytest.raises(ValidationError):
-            self._validate('{{ test_list|pprint }}')
+            self._validate("{{ test_list|pprint }}")


### PR DESCRIPTION
- Add [black](https://pypi.org/project/black/) formatter as a dependency
- Update flake8 and isort configurations to work with black
- Add a CI step to check black formatting
- Reformat all Python files with black
- Add `.git-blame-ignore-revs` file to ignore the black reformatting commit from the Git blame