### PR TITLE
Only run black on `src/` and `tests/` directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Validate Python syntax with flake8
         run: flake8 --config .flake8 src tests
       - name: Check Python formatting with black
-        run: black --check .
+        run: black --check src tests
       - name: Run tests
         run: python run_tests.py


### PR DESCRIPTION
Use the same logic for running black, flake8, isort and mypy