### PR TITLE
Add official support for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Update `pyproject.toml`
     - Add contributing guidelines to `README.md`
 - Sort filters by alphabetical order in the documentation and source code
+- Add official support for Python 3.12
 
 ## 1.1.0 - 2024-02-04
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Django template engine to render untrusted template code
 
 ## Requirements
 
-- Python 3.8 to 3.11
+- Python 3.8 to 3.12
 - Django 3.2 (officially supported in automated tests, all built-in template tags and filters reviewed)
 
 ## Available tools


### PR DESCRIPTION
- Add Python 3.12 to the GitHub Actions test matrix
- Update requirements on README