### PR TITLE
Remove "Homepage" from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project.urls]
-Homepage = "https://github.com/ronanboiteau/django_safe_template_engine"
 Documentation = "https://github.com/ronanboiteau/django_safe_template_engine/blob/main/README.md"
 Repository = "https://github.com/ronanboiteau/django_safe_template_engine.git"
 Issues = "https://github.com/ronanboiteau/django_safe_template_engine/issues"


### PR DESCRIPTION
Remove "Homepage" from `pyproject.toml`. It's not really needed, the link is just a duplicate of "Repository".