### PR TITLE
Support Django 3.0 to 5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,20 @@ on: [push]
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Set up Python
         uses: actions/setup-python@v4
       - name: Install tox
         run: pip install tox
       - name: Use tox to run test suite
-        run: tox run
+        run: python -m tox -f py$(echo ${{ matrix.python-version }} | tr -d .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,10 @@ on: [push]
 jobs:
   run_tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: pip install tox
       - name: Use tox to run test suite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up Python
-        uses: actions/setup-python@v4
       - name: Install tox
         run: pip install tox
       - name: Use tox to run test suite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Use tox to run test suite
-        run: python -m tox -f py$(echo ${{ matrix.python-version }} | tr -d .)
+        run: python -m tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add official support for Django 4.0 to 4.2 with:
+- Add official support for Django 4.0 to 5.0 with:
     - Addition of automated test coverage
     - Review of all the built-in template tags and filters (no changes needed)
 - Use [tox](https://tox.wiki/) to manage test suite environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Lower Django version requirement to 3.0
+- Lower Python version requirement to 3.7
 - Add official support for Django 4.0 to 5.0 with:
     - Addition of automated test coverage
     - Review of all the built-in template tags and filters (no changes needed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.3.0 - 2024-04-18
 
 - Lower Django version requirement to 3.0
 - Lower Python version requirement to 3.7
-- Add official support for Django 4.0 to 5.0 with:
+- Add official support for Django 3.0 to 5.0 with:
     - Addition of automated test coverage
     - Review of all the built-in template tags and filters (no changes needed)
 - Use [tox](https://tox.wiki/) to manage test suite environment

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Django template engine to render untrusted template code
 
 ## Requirements
 
-Django 3.2 to 5.0
+Django 3.0 to 5.0
 
 ## Available tools
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Django template engine to render untrusted template code
 ## Requirements
 
 - Python 3.8 to 3.12
-- Django 3.2 to 4.2 (officially supported in automated tests, all built-in template tags and filters reviewed)
+- Django 3.2 to 5.0
 
 ## Available tools
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Django template engine to render untrusted template code
 
 ## Requirements
 
-- Python 3.8 to 3.12
-- Django 3.2 to 5.0
+Django 3.2 to 5.0
 
 ## Available tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "django_safe_template_engine"
 version = "1.2.0"
-dependencies = ["django >= 3.2"]
+dependencies = ["django >= 3.0"]
 requires-python = ">=3.8"
 authors = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]
 maintainers = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "django_safe_template_engine"
 version = "1.2.0"
-dependencies = ["django >= 3.2, < 5"]
+dependencies = ["django >= 3.2"]
 requires-python = ">=3.8"
 authors = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]
 maintainers = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,24 @@ readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["django", "safe", "template", "engine"]
 classifiers = [
-  "Programming Language :: Python :: 3",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Web Environment",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Framework :: Django",
+  "Framework :: Django :: 3.0",
+  "Framework :: Django :: 3.1",
+  "Framework :: Django :: 3.2",
+  "Framework :: Django :: 4.0",
+  "Framework :: Django :: 4.1",
+  "Framework :: Django :: 4.2",
+  "Framework :: Django :: 5.0",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django_safe_template_engine"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = ["django >= 3.0"]
 requires-python = ">=3.7"
 authors = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "django_safe_template_engine"
 version = "1.2.0"
 dependencies = ["django >= 3.0"]
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 authors = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]
 maintainers = [{ name = "Ronan Boiteau", email = "ronan@boiteau.eu" }]
 description = "A Django template engine to render untrusted template code"

--- a/run_tests.py
+++ b/run_tests.py
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
 
     import django
+
     django.setup()
 
     pytest.main()

--- a/src/django_safe_template_engine/trusted_filters.py
+++ b/src/django_safe_template_engine/trusted_filters.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.template.defaultfilters import (
     add,
     addslashes,
@@ -73,6 +74,12 @@ register.filter(dictsortreversed, is_safe=False)
 register.filter(divisibleby, is_safe=False)
 register.filter("escape", escape_filter, is_safe=True)
 register.filter("escapejs", escapejs_filter)
+
+if VERSION[0] == 5:
+    from django.template.defaultfilters import escapeseq
+
+    register.filter(escapeseq)
+
 register.filter(filesizeformat, is_safe=True)
 register.filter(first, is_safe=False)
 register.filter(floatformat, is_safe=True)

--- a/tests/filters/test_trusted_filters.py
+++ b/tests/filters/test_trusted_filters.py
@@ -58,8 +58,9 @@ class TestTrustedFilters:
         result = self._render('{{ "<test&test>"|escapejs }}')
         assert result == expected
 
-    def test_trust_escapeseq(self):
-        if VERSION[0] == 5:
+    if VERSION[0] == 5:
+
+        def test_trust_escapeseq(self):
             expected = "T&amp;Cs, &#x27;Test&#x27;"
             result = self._render(
                 '{{ value|escapeseq|join:", " }}',

--- a/tests/filters/test_trusted_filters.py
+++ b/tests/filters/test_trusted_filters.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.template.base import Template
 from django.template.context import Context
 
@@ -46,12 +47,25 @@ class TestTrustedFilters:
     # TODO: Write test for dictsort
     # TODO: Write test for dictsortreversed
     # TODO: Write test for divisibleby
-    # TODO: Write test for escape
+
+    def test_trust_escape(self):
+        expected = "&lt;b&gt;T&amp;Cs&lt;/b&gt;"
+        result = self._render("{{ value|escape }}", context={"value": "<b>T&Cs</b>"})
+        assert result == expected
 
     def test_trust_escapejs(self):
         expected = "\\u003Ctest\\u0026test\\u003E"
         result = self._render('{{ "<test&test>"|escapejs }}')
         assert result == expected
+
+    def test_trust_escapeseq(self):
+        if VERSION[0] == 5:
+            expected = "T&amp;Cs, &#x27;Test&#x27;"
+            result = self._render(
+                '{{ value|escapeseq|join:", " }}',
+                context={"value": ["T&Cs", "'Test'"]},
+            )
+            assert result == expected
 
     # FIXME
     # def test_trust_filesizeformat(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
 envlist =
-    django32,
-    django40,
-    django41,
-    django42,
+    {py36, py37, py38, py39}-django30,
+    {py36, py37, py38, py39}-django31,
+    {py36, py37, py38, py39, py310}-django32,
+    {py38, py39, py310}-django40,
+    {py38, py39, py310, py311}-django41,
+    {py38, py39, py310, py311, py312}-django42,
+    {py310, py311, py312}-django50,
     lint
 isolated_build = true
 
@@ -13,10 +16,13 @@ commands =
     python -m mypy --config-file mypy.ini src tests
     python run_tests.py
 deps =
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5
+    django50: Django>=5.0,<5.1
     pytest
     mypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py36, py37, py38, py39}-django30,
-    {py36, py37, py38, py39}-django31,
-    {py36, py37, py38, py39, py310}-django32,
+    {py37, py38, py39}-django30,
+    {py37, py38, py39}-django31,
+    {py37, py38, py39, py310}-django32,
     {py38, py39, py310}-django40,
     {py38, py39, py310, py311}-django41,
     {py38, py39, py310, py311, py312}-django42,


### PR DESCRIPTION
- Improve Python version matrix management between GitHub Actions and tox
- Add support for Django 5.0 (support new filter `escapeseq`)
- Lower version requirement for Django to 3.0
- Lower version requirement for Python to 3.7
- Update GitHub Actions dependencies
- Update PyPi classifiers
- Prepare for v1.3.0 release