### PR TITLE
Add support for Django 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add official support for Django 5.1
+- Add support for Django 5.1's `query_string` template tag
+
 ## 1.3.1 - 2024-04-18
 
 - Small fixes in changelog and README
@@ -11,7 +16,7 @@
 - Add official support for Django 3.0 to 5.0 with:
     - Addition of automated test coverage
     - Review of all the built-in template tags and filters
-- Add support for Django 5's `escapeseq` filter
+- Add support for Django 5's `escapeseq` template filter
 - Use [tox](https://tox.wiki/) to manage test suite environment
 
 ## 1.2.0 - 2024-04-18

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Django template engine to render untrusted template code
 
 ## Requirements
 
-Django 3.0 to 5.0
+Django 3.0 to 5.1
 
 ## Available tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Environment :: Web Environment",
   "Intended Audience :: Developers",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
@@ -28,6 +29,7 @@ classifiers = [
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
 ]

--- a/src/django_safe_template_engine/trusted_filters.py
+++ b/src/django_safe_template_engine/trusted_filters.py
@@ -75,7 +75,7 @@ register.filter(divisibleby, is_safe=False)
 register.filter("escape", escape_filter, is_safe=True)
 register.filter("escapejs", escapejs_filter)
 
-if VERSION[0] == 5:
+if VERSION >= (5, 0):
     from django.template.defaultfilters import escapeseq
 
     register.filter(escapeseq)

--- a/src/django_safe_template_engine/trusted_tags.py
+++ b/src/django_safe_template_engine/trusted_tags.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.template.defaulttags import (
     autoescape,
     comment,
@@ -32,6 +33,12 @@ register.tag("if", do_if)
 register.tag(ifchanged)
 register.tag(lorem)
 register.tag(now)
+
+if VERSION >= (5, 1):
+    from django.template.defaulttags import query_string
+
+    register.filter(query_string)
+
 register.tag(regroup)
 register.tag(resetcycle)
 register.tag(spaceless)

--- a/tests/filters/test_trusted_filters.py
+++ b/tests/filters/test_trusted_filters.py
@@ -58,7 +58,7 @@ class TestTrustedFilters:
         result = self._render('{{ "<test&test>"|escapejs }}')
         assert result == expected
 
-    if VERSION[0] == 5:
+    if VERSION >= (5, 0):
 
         def test_trust_escapeseq(self):
             expected = "T&amp;Cs, &#x27;Test&#x27;"

--- a/tests/tags/test_trusted_tags.py
+++ b/tests/tags/test_trusted_tags.py
@@ -1,4 +1,5 @@
 import pytest
+from django import VERSION
 from django.template.base import Template
 from django.template.context import Context
 from django.template.exceptions import TemplateSyntaxError
@@ -141,6 +142,13 @@ class TestTrustedTags:
         expected = ["0", "1"]
         result = self._render('{% now "I" %}')
         assert result in expected
+
+    if VERSION >= (5, 1):
+
+        def test_query_string(self):
+            expected = "?color=red&size=S"
+            result = self._render('{% query_string color="red" size="S" %}')
+            assert result == expected
 
     # TODO: Write test for regroup
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     {py38, py39, py310, py311}-django41,
     {py38, py39, py310, py311, py312}-django42,
     {py310, py311, py312}-django50,
+    {py310, py311, py312}-django51,
     lint
 isolated_build = true
 
@@ -23,6 +24,7 @@ deps =
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5
     django50: Django>=5.0,<5.1
+    django51: Django>=5.1a1,<5.2
     pytest
     mypy
 


### PR DESCRIPTION
- Add support for Django 5.1's new [`query_string`](https://docs.djangoproject.com/en/dev/ref/templates/builtins/#std-templatetag-query_string) template tag
- Add official support for Django 5.1 with test coverage