### PR TITLE
Exit `run_tests.py` with the pytest exit code

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -8,5 +8,6 @@ if __name__ == "__main__":
     import django
 
     django.setup()
+    exit_code = pytest.main()
 
-    pytest.main()
+    exit(exit_code)


### PR DESCRIPTION
Make sure we exit `run_tests.py` with the exit code returned by pytest.

This will avoid silent failures like [this one](https://github.com/ronanboiteau/django_safe_template_engine/actions/runs/9373791398/job/25808358828) in the CI:

<img width="1052" alt="image" src="https://github.com/ronanboiteau/django_safe_template_engine/assets/3595480/9ce73259-e62c-4f2b-a86e-b2ef93088a46">
